### PR TITLE
Add a warm up run to init things before measurement

### DIFF
--- a/bert.py
+++ b/bert.py
@@ -32,7 +32,10 @@ model = prepare_pippy(model, split_points="auto", example_args=(input,))
 # Move the inputs to the first device
 input = input.to("cuda:0")
 
-# Take an average of 5 times
+# Warm up (NCCL init, etc)
+with torch.no_grad():
+    output = model(input)
+
 # Measure first batch
 torch.cuda.synchronize()
 start_time = time.time()

--- a/gpt2.py
+++ b/gpt2.py
@@ -32,7 +32,10 @@ model = prepare_pippy(model, split_points="auto", example_args=(input,))
 # Move the inputs to the first device
 input = input.to("cuda:0")
 
-# Take an average of 5 times
+# Warm up (NCCL init, etc)
+with torch.no_grad():
+    output = model(input)
+
 # Measure first batch
 torch.cuda.synchronize()
 start_time = time.time()

--- a/t5.py
+++ b/t5.py
@@ -41,7 +41,10 @@ args = (
     example_inputs["decoder_input_ids"].to("cuda:0")
 )
 
-# Take an average of 5 times
+# Warm up (NCCL init, etc)
+with torch.no_grad():
+    output = model(*args)
+
 # Measure first batch
 torch.cuda.synchronize()
 start_time = time.time()


### PR DESCRIPTION
ProcessGroupNCCL, for example, lazily inits NCCL communicator upon the first collective.